### PR TITLE
Add availability to send json as a queue config path

### DIFF
--- a/Sources/ResourceLocation/ResourceLocation.swift
+++ b/Sources/ResourceLocation/ResourceLocation.swift
@@ -47,13 +47,16 @@ public enum ResourceLocation: Hashable, CustomStringConvertible, Codable {
         case headers
     }
     
-    public static func from(_ string: String, headers: [String: String] = [:]) throws -> ResourceLocation {
+    public static func from(_ string: String) throws -> ResourceLocation {
+        if let decoded = try? JSONDecoder().decode(self, from: Data(string.utf8)) {
+            return decoded
+        }
         let components = try urlComponents(string)
         guard let url = components.url else { throw ValidationError.cannotCreateUrl(string) }
         if url.isFileURL {
             return try withPathString(string)
         } else {
-            return withUrl(url, headers)
+            return withUrl(url, [:])
         }
     }
     

--- a/Tests/ResourceLocationTests/ResourceLocationTests.swift
+++ b/Tests/ResourceLocationTests/ResourceLocationTests.swift
@@ -97,5 +97,16 @@ final class ResourceLocationTests: XCTestCase {
         let decoded = try JSONDecoder().decode(ResourceLocation.self, from: jsonData)
         XCTAssertEqual(decoded, ResourceLocation.localFilePath("/path/to/file name.txt"))
     }
+    
+    func test__decoding_string_with_headers() throws {
+            let value = """
+            {"url": "https://example.url", "headers": {"h1": "v1"}}
+            """
+            let decoded = try ResourceLocation.from(value)
+            XCTAssertEqual(
+                decoded,
+                ResourceLocation.remoteUrl(URL(string: "https://example.url")!, ["h1": "v1"])
+            )
+        }
 }
 


### PR DESCRIPTION
In this pull request, I added headders to artifact urls. One problem remained - it was impossible to add headders to the path before the queue-server-configuration-location. 

After this fix, you can use json as a parameter for the queue config path.

Example:

`emcee runTestsOnRemoteQueue --queue-server-configuration-location '{"url": "https://example.url", "headers": {"h1": "v1"}}'...`