### PR TITLE
Fix adding headers to config path

### DIFF
--- a/Sources/DistDeployer/RemoteQueueLaunchdPlist.swift
+++ b/Sources/DistDeployer/RemoteQueueLaunchdPlist.swift
@@ -56,7 +56,7 @@ public final class RemoteQueueLaunchdPlist {
                 programArguments: [
                     remoteQueueServerBinaryPath.pathString, "startLocalQueueServer",
                     "--emcee-version", emceeVersion.value,
-                    "--queue-server-configuration-location", queueServerConfigurationLocation.resourceLocation.stringValue
+                    "--queue-server-configuration-location", try queueServerConfigurationLocation.resourceLocation.stringValue()
                 ],
                 environmentVariables: [:],
                 workingDirectory: containerPath.pathString,

--- a/Sources/ResourceLocation/ResourceLocation.swift
+++ b/Sources/ResourceLocation/ResourceLocation.swift
@@ -112,12 +112,21 @@ public enum ResourceLocation: Hashable, CustomStringConvertible, Codable {
         }
     }
     
-    public var stringValue: String {
+    public func stringValue() throws -> String {
         switch self {
         case .localFilePath(let path):
             return path
-        case .remoteUrl(let url, _):
-            return url.absoluteString
+        case .remoteUrl(let url, let headers):
+            guard let headers = headers,
+                  headers.count > 0 else {
+                return url.absoluteString
+            }
+            let params: [String: Encodable] = [
+                "url": url.absoluteString,
+                "headers": headers
+            ]
+            let data = try JSONSerialization.data(withJSONObject: params, options: .fragmentsAllowed)
+            return String(data: data, encoding: .utf8) ?? ""
         }
     }
     

--- a/Sources/ResourceLocation/ResourceLocation.swift
+++ b/Sources/ResourceLocation/ResourceLocation.swift
@@ -121,12 +121,17 @@ public enum ResourceLocation: Hashable, CustomStringConvertible, Codable {
                   headers.count > 0 else {
                 return url.absoluteString
             }
-            let params: [String: Encodable] = [
-                "url": url.absoluteString,
-                "headers": headers
-            ]
-            let data = try JSONSerialization.data(withJSONObject: params, options: .fragmentsAllowed)
-            return String(data: data, encoding: .utf8) ?? ""
+            struct Params: Encodable {
+                let url: String
+                let headers: [String: String]
+            }
+            let params = Params(url: url.absoluteString, headers: headers)
+            let data = try JSONEncoder().encode(params)
+            if let result = String(data: data, encoding: .utf8) {
+                return result
+            } else {
+                throw ResourceLocationError.encodeRemoteUrl(url: url.absoluteString)
+            }
         }
     }
     

--- a/Sources/ResourceLocation/ResourceLocationError.swift
+++ b/Sources/ResourceLocation/ResourceLocationError.swift
@@ -1,0 +1,12 @@
+import Foundation
+
+public enum ResourceLocationError: Error, CustomStringConvertible {
+    case encodeRemoteUrl(url: String)
+    
+    public var description: String {
+        switch self {
+        case .encodeRemoteUrl(let url):
+            return "Can't encode resource location for \(url)"
+        }
+    }
+}

--- a/Sources/TestDiscovery/RuntimeDumpRemoteCache/DefaultRuntimeDumpRemoteCache.swift
+++ b/Sources/TestDiscovery/RuntimeDumpRemoteCache/DefaultRuntimeDumpRemoteCache.swift
@@ -67,7 +67,7 @@ class DefaultRuntimeDumpRemoteCache: RuntimeDumpRemoteCache {
     }
 
     private func pathToRemoteFile(_ xcTestBundleLocation: TestBundleLocation) throws -> String {
-        let remoteFileName = try xcTestBundleLocation.resourceLocation.stringValue.avito_sha256Hash()
+        let remoteFileName = try xcTestBundleLocation.resourceLocation.stringValue().avito_sha256Hash()
 
         return addLeadingSlashIfNeeded(config.relativePathToRemoteStorage).appending(
             pathComponent: "\(remoteFileName).json"

--- a/Sources/TestDiscovery/TestDiscoveryQuerierImpl.swift
+++ b/Sources/TestDiscovery/TestDiscoveryQuerierImpl.swift
@@ -198,7 +198,14 @@ public final class TestDiscoveryQuerierImpl: TestDiscoveryQuerier {
         configuration: TestDiscoveryConfiguration,
         specificMetricRecorder: SpecificMetricRecorder
     ) throws {
-        let testBundleName = try configuration.xcTestBundleLocation.resourceLocation.stringValue().lastPathComponent
+        let lastPathComponent: String
+        switch configuration.xcTestBundleLocation.resourceLocation {
+        case .localFilePath(_):
+            lastPathComponent = try configuration.xcTestBundleLocation.resourceLocation.stringValue().lastPathComponent
+        case .remoteUrl(let url, _):
+            lastPathComponent = url.lastPathComponent
+        }
+        let testBundleName = lastPathComponent
         configuration.logger.info("Test discovery in \(configuration.xcTestBundleLocation.resourceLocation): bundle has \(testCaseCount) XCTestCases, \(testCount) tests")
         specificMetricRecorder.capture(
             RuntimeDumpTestCountMetric(

--- a/Sources/TestDiscovery/TestDiscoveryQuerierImpl.swift
+++ b/Sources/TestDiscovery/TestDiscoveryQuerierImpl.swift
@@ -129,7 +129,7 @@ public final class TestDiscoveryQuerierImpl: TestDiscoveryQuerier {
                 }
                 
                 let allTests = foundTestEntries.flatMap { $0.testMethods }
-                reportStats(
+                try reportStats(
                     testCaseCount: foundTestEntries.count,
                     testCount: allTests.count,
                     configuration: configuration,
@@ -197,8 +197,8 @@ public final class TestDiscoveryQuerierImpl: TestDiscoveryQuerier {
         testCount: Int,
         configuration: TestDiscoveryConfiguration,
         specificMetricRecorder: SpecificMetricRecorder
-    ) {
-        let testBundleName = configuration.xcTestBundleLocation.resourceLocation.stringValue.lastPathComponent
+    ) throws {
+        let testBundleName = try configuration.xcTestBundleLocation.resourceLocation.stringValue().lastPathComponent
         configuration.logger.info("Test discovery in \(configuration.xcTestBundleLocation.resourceLocation): bundle has \(testCaseCount) XCTestCases, \(testCount) tests")
         specificMetricRecorder.capture(
             RuntimeDumpTestCountMetric(

--- a/Tests/ResourceLocationTests/ResourceLocationTests.swift
+++ b/Tests/ResourceLocationTests/ResourceLocationTests.swift
@@ -74,14 +74,14 @@ final class ResourceLocationTests: XCTestCase {
         XCTAssertEqual(headers["key"], "value")
     }
     
-    func test___string_value() {
-        XCTAssertEqual(ResourceLocation.localFilePath("/path").stringValue, "/path")
+    func test___string_value() throws {
+        XCTAssertEqual(try ResourceLocation.localFilePath("/path").stringValue(), "/path")
         XCTAssertEqual(
-            ResourceLocation.remoteUrl(URL(string: "http://example.com/file.zip")!, [:]).stringValue,
+            try ResourceLocation.remoteUrl(URL(string: "http://example.com/file.zip")!, [:]).stringValue(),
             "http://example.com/file.zip"
         )
         XCTAssertEqual(
-            ResourceLocation.remoteUrl(URL(string: "http://example.com/file.zip#file")!, [:]).stringValue,
+            try ResourceLocation.remoteUrl(URL(string: "http://example.com/file.zip#file")!, [:]).stringValue(),
             "http://example.com/file.zip#file"
         )
     }

--- a/Tests/TestDiscoveryTests/ExecutableTestDiscovererTests.swift
+++ b/Tests/TestDiscoveryTests/ExecutableTestDiscovererTests.swift
@@ -167,12 +167,12 @@ final class ExecutableTestDiscovererTests: XCTestCase {
         onSubprocessCreate: ((Subprocess) -> ())? = nil,
         simctlResponse: String,
         executableResponse: String
-    ) -> ExecutableTestDiscoverer {
+    ) throws -> ExecutableTestDiscoverer {
         return ExecutableTestDiscoverer(
             appBundleLocation: appBundleLocation,
             developerDirLocator: FakeDeveloperDirLocator(result: AbsolutePath("/path/to/developer_dir")),
             resourceLocationResolver: FakeResourceLocationResolver.resolvingTo(
-                path: AbsolutePath(testBundleLocation.resourceLocation.stringValue)
+                path: AbsolutePath(try testBundleLocation.resourceLocation.stringValue())
             ),
             processControllerProvider: FakeProcessControllerProvider { subprocess in
                 onSubprocessCreate?(subprocess)


### PR DESCRIPTION
In this [PR](https://github.com/avito-tech/Emcee/pull/26) I added the ability to pass headers along with the path for the server configuration. 
A bug is fixed here - headers were not sent to the queue builder