### PR TITLE
Change key path absolute to relative path

### DIFF
--- a/Sources/Deployer/DeploymentDestinationAuthenticationType.swift
+++ b/Sources/Deployer/DeploymentDestinationAuthenticationType.swift
@@ -3,20 +3,28 @@ import PathLib
 
 public enum DeploymentDestinationAuthenticationType: Codable, CustomStringConvertible, Equatable, Hashable {
     case password(String)
+    
+    /// Absolute (arbitrary) path to a local key file.
     case key(path: AbsolutePath)
+    
+    // Look up a key inside ~/.ssh/
+    case keyInDefaultSshLocation(filename: String)
     
     public var description: String {
         switch self {
         case .password:
             return "password auth"
         case .key:
-            return "key authorization"
+            return "authorization using a key file at absolute path"
+        case .keyInDefaultSshLocation:
+            return "authorization using key from ~/.ssh/"
         }
     }
     
     private enum CodingKeys: String, CodingKey {
         case password
         case keyPath
+        case filename
     }
     
     public init(from decoder: Decoder) throws {
@@ -24,7 +32,12 @@ public enum DeploymentDestinationAuthenticationType: Codable, CustomStringConver
         do {
             self = .password(try container.decode(String.self, forKey: .password))
         } catch {
-            self = .key(path: try container.decode(AbsolutePath.self, forKey: .keyPath))
+            do {
+                self = .key(path: try container.decode(AbsolutePath.self, forKey: .keyPath))
+            } catch {
+                self = .keyInDefaultSshLocation(filename: try container.decode(String.self, forKey: .filename))
+            }
+            
         }
     }
     
@@ -35,6 +48,8 @@ public enum DeploymentDestinationAuthenticationType: Codable, CustomStringConver
             try container.encode(password, forKey: .password)
         case .key(let path):
             try container.encode(path, forKey: .keyPath)
+        case .keyInDefaultSshLocation(let filename):
+            try container.encode(filename, forKey: .filename)
         }
     }
 }

--- a/Sources/SSHDeployer/DefaultSSHClient.swift
+++ b/Sources/SSHDeployer/DefaultSSHClient.swift
@@ -20,6 +20,8 @@ public final class DefaultSSHClient: SSHClient {
             try ssh.authenticate(username: username, password: password)
         case .key(let path):
             try ssh.authenticate(username: username, privateKey: path.pathString)
+        case .keyInDefaultSshLocation(filename: let filename):
+            try ssh.authenticate(username: username, privateKey: "~/.ssh/\(filename)")
         }
     }
     

--- a/Tests/LocalQueueServerRunnerTests/QueueServerConfigurationTests.swift
+++ b/Tests/LocalQueueServerRunnerTests/QueueServerConfigurationTests.swift
@@ -117,4 +117,24 @@ final class QueueServerConfigurationTests: XCTestCase {
             DeploymentDestination(host: "host", port: 1, username: "username", authentication: .key(path: "/path/to/key"), remoteDeploymentPath: "/remote/deployment/path")
         )
     }
+    
+    func test___deployment_destination_with_default_location_key_parsing() throws {
+        let data = Data("""
+            {
+                "host": "host",
+                "port": 1,
+                "username": "username",
+                "authentication": {
+                    "filename": "key"
+                },
+                "remoteDeploymentPath": "/remote/deployment/path"
+            }
+        """.utf8
+        )
+        let config = try JSONDecoder().decode(DeploymentDestination.self, from: data)
+        XCTAssertEqual(
+            config,
+            DeploymentDestination(host: "host", port: 1, username: "username", authentication: .keyInDefaultSshLocation(filename: "key"), remoteDeploymentPath: "/remote/deployment/path")
+        )
+    }
 }


### PR DESCRIPTION
By default, the keys for ssh connections are in `~/.ssh /key`. There was a problem with the absolute path - if the keys are configured identically on all builders, then using the universal path for the key was impossible (`/Users/builder_1/...`, `/Users/builder_2/...`).
I think it would be wise to use a relative path.